### PR TITLE
修复图片缓存到数据库时date未被正确赋值的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export function apply(ctx: Context, config: Config) {
     }
     let databaseImg = await ctx.database.get('news', getCurrentDate());
     if (databaseImg.length == 1) return databaseImg[0].img;
+    date = getCurrentDate()
     const img = await fetchNewsImage(ctx.config.api);
     const yesterday = await ctx.database.get(
       'news',


### PR DESCRIPTION
Fix #3
现在使用缺省了日期参数的news命令来获取当日新闻后，图片会使用当前日期作为`time`的值缓存到数据库中。
注意到指明和缺省日期参数时使用的是不同的API，所以数据库里会同时混有两个API返回的新闻图片（两个API返回的图片样式似乎略有不同），不知道这是否符合预期。